### PR TITLE
ci: changing the ci pipeline to depend on docker without swarm mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,134 +1,134 @@
-name: Build Pipeline
+# name: Build Pipeline
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     branches:
+#       - main
 
-env:
-  VAR_NAMES: NEXT_PUBLIC_API_BASE_URL APP_PORT API_URL
-  NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
-  APP_PORT: ${{ secrets.APP_PORT }}
-  API_URL: ${{ secrets.API_URL }}
+# env:
+#   VAR_NAMES: NEXT_PUBLIC_API_BASE_URL APP_PORT API_URL
+#   NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
+#   APP_PORT: ${{ secrets.APP_PORT }}
+#   API_URL: ${{ secrets.API_URL }}
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       packages: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4.2.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@v3.10.0
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4.2.3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+#       - name: Cache Docker layers
+#         uses: actions/cache@v4.2.3
+#         with:
+#           path: /tmp/.buildx-cache
+#           key: ${{ runner.os }}-buildx-${{ github.sha }}
+#           restore-keys: |
+#             ${{ runner.os }}-buildx-
 
-      - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
-        with:
-          version: latest
+#       - name: Set up Docker Compose
+#         uses: docker/setup-compose-action@v1
+#         with:
+#           version: latest
 
-      - name: Debug Logs
-        run: ls
+#       - name: Debug Logs
+#         run: ls
 
-      - name: Build Docker images with Docker Compose
-        run: |
-          docker compose -f docker-compose.prod.yml build
+#       - name: Build Docker images with Docker Compose
+#         run: |
+#           docker compose -f docker-compose.prod.yml build
 
-      - name: Initialize Docker Swarm
-        run: docker swarm init
+#       - name: Initialize Docker Swarm
+#         run: docker swarm init
 
-      - name: Write secrets to files
-        run: |
-          mkdir -p secrets
-          for key in $VAR_NAMES; do
-            value="${!key}"
-            echo "$value" > "secrets/${key,,}.txt"
-          done
+#       - name: Write secrets to files
+#         run: |
+#           mkdir -p secrets
+#           for key in $VAR_NAMES; do
+#             value="${!key}"
+#             echo "$value" > "secrets/${key,,}.txt"
+#           done
 
-      - name: Run Docker Stack Deploy
-        run: |
-          docker stack deploy -c docker-compose.prod.yml prod
+#       - name: Run Docker Stack Deploy
+#         run: |
+#           docker stack deploy -c docker-compose.prod.yml prod
 
-      - name: Wait for 30 seconds
-        run: sleep 30
+#       - name: Wait for 30 seconds
+#         run: sleep 30
 
-      - name: Logging Docker Services
-        run: |
-          echo "🧩 Listing Docker services..."
-          docker service ls
+#       - name: Logging Docker Services
+#         run: |
+#           echo "🧩 Listing Docker services..."
+#           docker service ls
 
-      - name: Check service logs for frontend
-        run: |
-          echo "🔍 Checking logs for frontend (prod_app)..."
-          logs=$(docker service logs prod_app)
-          echo "$logs"
+#       - name: Check service logs for frontend
+#         run: |
+#           echo "🔍 Checking logs for frontend (prod_app)..."
+#           logs=$(docker service logs prod_app)
+#           echo "$logs"
 
-      - name: Check service logs for backend
-        run: |
-          echo "🔍 Checking logs for backend (prod_api)..."
-          logs=$(docker service logs prod_api)
-          echo "$logs"
+#       - name: Check service logs for backend
+#         run: |
+#           echo "🔍 Checking logs for backend (prod_api)..."
+#           logs=$(docker service logs prod_api)
+#           echo "$logs"
 
-      - name: Check if all services are running
-        run: |
-          echo "🔍 Checking if all services are running..."
+#       - name: Check if all services are running
+#         run: |
+#           echo "🔍 Checking if all services are running..."
 
-          services=$(docker stack services prod --format '{{.Name}} {{.Replicas}}')
+#           services=$(docker stack services prod --format '{{.Name}} {{.Replicas}}')
 
-          failed=0
+#           failed=0
 
-          while read name replicas; do
-            desired=$(echo "$replicas" | cut -d/ -f2)
-            running=$(echo "$replicas" | cut -d/ -f1)
+#           while read name replicas; do
+#             desired=$(echo "$replicas" | cut -d/ -f2)
+#             running=$(echo "$replicas" | cut -d/ -f1)
 
-            echo "🔧 Service: $name | Running: $running | Desired: $desired"
+#             echo "🔧 Service: $name | Running: $running | Desired: $desired"
 
-            if [ "$running" != "$desired" ]; then
-              echo "❌ Service $name is not fully running ($running/$desired)"
-              failed=1
-            fi
-          done <<< "$services"
+#             if [ "$running" != "$desired" ]; then
+#               echo "❌ Service $name is not fully running ($running/$desired)"
+#               failed=1
+#             fi
+#           done <<< "$services"
 
-          if [ "$failed" -eq 1 ]; then
-            echo "❌ One or more services failed to reach desired state."
-            exit 1
-          else
-            echo "✅ All services are running."
-          fi
+#           if [ "$failed" -eq 1 ]; then
+#             echo "❌ One or more services failed to reach desired state."
+#             exit 1
+#           else
+#             echo "✅ All services are running."
+#           fi
 
-      # Uncomment for debugging
-      # - name: SSH into runner (tmate session)
-      #   uses: mxschmitt/action-tmate@v3
-      #   with:
-      #     limit-access-to-actor: true
-      #   timeout-minutes: 30
+#       # Uncomment for debugging
+#       # - name: SSH into runner (tmate session)
+#       #   uses: mxschmitt/action-tmate@v3
+#       #   with:
+#       #     limit-access-to-actor: true
+#       #   timeout-minutes: 30
 
-      - name: Close Docker Setup
-        run: |
-          docker compose -f docker-compose.prod.yml down -v
-          docker stack rm prod
+#       - name: Close Docker Setup
+#         run: |
+#           docker compose -f docker-compose.prod.yml down -v
+#           docker stack rm prod
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#       - name: Log in to GitHub Container Registry
+#         uses: docker/login-action@v3.4.0
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.actor }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Docker images to GHCR
-        run: |
-          docker compose -f docker-compose.prod.yml push
+#       - name: Push Docker images to GHCR
+#         run: |
+#           docker compose -f docker-compose.prod.yml push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@
 #       - main
 
 # env:
-#   VAR_NAMES: NEXT_PUBLIC_API_BASE_URL APP_PORT API_URL
+#   VAR_NAMES: NEXT_PUBLIC_API_BASE_URL API_PORT API_URL
 #   NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
-#   APP_PORT: ${{ secrets.APP_PORT }}
+#   API_PORT: ${{ secrets.API_PORT }}
 #   API_URL: ${{ secrets.API_URL }}
 
 # jobs:

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -55,10 +55,6 @@ jobs:
       #     limit-access-to-actor: true
       #   timeout-minutes: 30
 
-      - name: Close Docker Setup
-        run: |
-          docker compose -f docker-compose.prod.yml down -v
-
       # - name: Log in to GitHub Container Registry
       #   uses: docker/login-action@v3.4.0
       #   with:

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -1,0 +1,71 @@
+name: Build Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  VAR_NAMES: NEXT_PUBLIC_API_BASE_URL APP_PORT API_URL
+  NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
+  APP_PORT: ${{ secrets.APP_PORT }}
+  API_URL: ${{ secrets.API_URL }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4.2.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+
+      - name: Debug Logs
+        run: ls
+
+      - name: Build Docker images with Docker Compose
+        run: |
+          docker compose -f docker-compose.prod.yml build
+
+      # Uncomment for debugging
+      # - name: SSH into runner (tmate session)
+      #   uses: mxschmitt/action-tmate@v3
+      #   with:
+      #     limit-access-to-actor: true
+      #   timeout-minutes: 30
+
+      - name: Close Docker Setup
+        run: |
+          docker compose -f docker-compose.prod.yml down -v
+
+      # - name: Log in to GitHub Container Registry
+      #   uses: docker/login-action@v3.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Push Docker images to GHCR
+      #   run: |
+      #     docker compose -f docker-compose.prod.yml push

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Check container statuses and logs
         run: |
-          docker compose ps
+          docker compose -f docker-compose.prod.yml ps
 
-          if [[ $(docker compose ps -q | xargs docker inspect -f '{{.State.Status}}' | wc -l) -lt 1 ]]; then
+          if [[ $(docker compose -f docker-compose.prod.yml ps -q | xargs docker inspect -f '{{.State.Status}}' | wc -l) -lt 1 ]]; then
             echo "One or more containers failed to start." && exit 1
           fi
 

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -55,13 +55,13 @@ jobs:
       #     limit-access-to-actor: true
       #   timeout-minutes: 30
 
-      # - name: Log in to GitHub Container Registry
-      #   uses: docker/login-action@v3.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Push Docker images to GHCR
-      #   run: |
-      #     docker compose -f docker-compose.prod.yml push
+      - name: Push Docker images to GHCR
+        run: |
+          docker compose -f docker-compose.prod.yml push

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -52,11 +52,11 @@ jobs:
         run: |
           docker compose -f docker-compose.prod.yml ps
 
-          if [[ $(docker compose -f docker-compose.prod.yml ps -q | xargs docker inspect -f '{{.State.Status}}' | wc -l) -lt 1 ]]; then
+          if [[ $(docker compose -f docker-compose.prod.yml ps -q | xargs docker inspect -f '{{.State.Status}}' | wc -l) -le 1 ]]; then
             echo "One or more containers failed to start." && exit 1
           fi
 
-          docker compose logs
+          docker compose -f docker-compose.prod.yml logs
 
       # Uncomment for debugging
       # - name: SSH into runner (tmate session)

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -41,9 +41,22 @@ jobs:
         with:
           version: latest
 
-      - name: Build Docker images with Docker Compose
+      - name: Build and Run Docker images with Docker Compose
         run: |
-          docker compose -f docker-compose.prod.yml build
+          docker compose -f docker-compose.prod.yml up -d --build
+
+      - name: Wait for 30 seconds
+        run: sleep 30
+
+      - name: Check container statuses and logs
+        run: |
+          docker compose ps
+
+          if [[ $(docker compose ps -q | xargs docker inspect -f '{{.State.Status}}' | wc -l) -lt 1 ]]; then
+            echo "One or more containers failed to start." && exit 1
+          fi
+
+          docker compose logs
 
       # Uncomment for debugging
       # - name: SSH into runner (tmate session)

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           version: latest
 
-      - name: Debug Logs
-        run: ls
-
       - name: Build Docker images with Docker Compose
         run: |
           docker compose -f docker-compose.prod.yml build

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           version: latest
 
-      - name: Build and Run Docker images with Docker Compose
+      - name: Build Docker images with Docker Compose
         run: |
-          docker compose -f docker-compose.prod.yml up --build
+          docker compose -f docker-compose.prod.yml build
 
       # Uncomment for debugging
       # - name: SSH into runner (tmate session)

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           version: latest
 
-      - name: Build Docker images with Docker Compose
+      - name: Build and Run Docker images with Docker Compose
         run: |
-          docker compose -f docker-compose.prod.yml build
+          docker compose -f docker-compose.prod.yml up --build
 
       # Uncomment for debugging
       # - name: SSH into runner (tmate session)

--- a/.github/workflows/buildv2.yml
+++ b/.github/workflows/buildv2.yml
@@ -9,9 +9,9 @@ on:
       - main
 
 env:
-  VAR_NAMES: NEXT_PUBLIC_API_BASE_URL APP_PORT API_URL
+  VAR_NAMES: NEXT_PUBLIC_API_BASE_URL API_PORT API_URL
   NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
-  APP_PORT: ${{ secrets.APP_PORT }}
+  API_PORT: ${{ secrets.API_PORT }}
   API_URL: ${{ secrets.API_URL }}
 
 jobs:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,7 +20,6 @@ services:
       dockerfile: Dockerfile.dev
     env_file:
       - ./client/.env.dev
-
     volumes:
       - ./client:/app
       - /app/node_modules

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile.prod
+    env_file:
+      - ./server/.env.prod
     ports:
       - "8000:8000"
     cap_drop:
@@ -14,22 +16,25 @@ services:
     security_opt:
       - no-new-privileges:true
     read_only: true
-    volumes:
-      - type: tmpfs
-        target: /tmp
-        tmpfs:
-          size: 104857600 # 100MB
-          mode: 1777
-      - type: tmpfs
-        target: /tmp/videos
-        tmpfs:
-          size: 104857600 # 100MB
-          mode: 1777
-      - type: tmpfs
-        target: /tmp/audio
-        tmpfs:
-          size: 104857600 # 100MB
-          mode: 1777
+    # volumes:
+    #   - type: tmpfs
+    #     target: /tmp
+    #     tmpfs:
+    #       size: 104857600 # 100MB
+    #       mode: 1777
+    #   - type: tmpfs
+    #     target: /tmp/videos
+    #     tmpfs:
+    #       size: 104857600 # 100MB
+    #       mode: 1777
+    #   - type: tmpfs
+    #     target: /tmp/audio
+    #     tmpfs:
+    #       size: 104857600 # 100MB
+    #       mode: 1777
+    tmpfs:
+      - /tmp/vidoes
+      - /tmp/audio
 
     restart: on-failure:5
     networks:
@@ -50,14 +55,13 @@ services:
     ulimits:
       nofile: 1024
       nproc: 256
-    secrets:
-      - app_port
-      - api_url
   app:
     image: ghcr.io/she11fish/youtubepitchtransposer-app:latest
     build:
       context: ./client
       dockerfile: Dockerfile.prod
+    env_file:
+      - ./client/.env.prod
     ports:
       - "3000:3000"
     cap_drop:
@@ -82,18 +86,9 @@ services:
     ulimits:
       nofile: 1024
       nproc: 256
-    secrets:
-      - next_public_api_base_url
 
 networks:
   app_network:
-    driver: overlay
-    attachable: true
-
-secrets:
-  app_port:
-    file: ./secrets/app_port.txt
-  api_url:
-    file: ./secrets/api_url.txt
-  next_public_api_base_url:
-    file: ./secrets/next_public_api_base_url.txt
+    # driver: overlay
+    # attachable: true
+    driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - API_PORT
       - API_URL
+      - APP_URL
     ports:
       - "8000:8000"
     cap_drop:
@@ -16,7 +17,7 @@ services:
       - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    read_only: true
+    # read_only: true
     # volumes:
     #   - type: tmpfs
     #     target: /tmp

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,8 +4,9 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile.prod
-    env_file:
-      - ./server/.env.prod
+    environment:
+      - APP_PORT
+      - API_URL
     ports:
       - "8000:8000"
     cap_drop:
@@ -35,7 +36,6 @@ services:
     tmpfs:
       - /tmp/vidoes
       - /tmp/audio
-
     restart: on-failure:5
     networks:
       - app_network
@@ -60,8 +60,8 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile.prod
-    env_file:
-      - ./client/.env.prod
+      environment:
+        - NEXT_PUBLIC_API_BASE_URL
     ports:
       - "3000:3000"
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,8 +60,8 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile.prod
-      environment:
-        - NEXT_PUBLIC_API_BASE_URL
+    environment:
+      - NEXT_PUBLIC_API_BASE_URL
     ports:
       - "3000:3000"
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@ services:
       context: ./server
       dockerfile: Dockerfile.prod
     environment:
-      - APP_PORT
+      - API_PORT
       - API_URL
     ports:
       - "8000:8000"

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
 WORKDIR /api
 
 # https://github.com/benoitc/gunicorn/issues/2859
-VOLUME ["/tmp"]
+# VOLUME ["/tmp"]
 
 COPY --from=builder /api /api
 COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -26,6 +26,9 @@ RUN apk add --no-cache \
 
 WORKDIR /api
 
+# https://github.com/benoitc/gunicorn/issues/2859
+VOLUME ["/tmp"]
+
 COPY --from=builder /api /api
 COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -6,16 +6,22 @@ import os
 class Config:
     """Base configuration class."""
 
-    APP_PORT = "app_port"
+    API_PORT = "api_port"
+    API_URL = "api_url"
 
 
 class DevelopmentConfig(Config):
     """Development-specific configuration."""
 
     @property
-    def APP_PORT(self):
+    def API_PORT(self):
         """Returns the application port."""
-        return DevelopmentConfig._read_secret(Config.APP_PORT)
+        return DevelopmentConfig._read_secret(Config.API_PORT)
+
+    @property
+    def API_URL(self):
+        """Returns the application port."""
+        return DevelopmentConfig._read_secret(Config.API_URL)
 
     @staticmethod
     def _read_secret(secret_name, default=None):
@@ -27,9 +33,14 @@ class ProductionConfig(Config):
     """Production-specific configuration."""
 
     @property
-    def APP_PORT(self):
+    def API_PORT(self):
         """Returns the application port."""
-        return ProductionConfig._read_secret(Config.APP_PORT)
+        return ProductionConfig._read_secret(Config.API_PORT)
+
+    @property
+    def API_URL(self):
+        """Returns the application port."""
+        return ProductionConfig._read_secret(Config.API_URL)
 
     @staticmethod
     def _read_secret(secret_name, default=None):

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -8,6 +8,7 @@ class Config:
 
     API_PORT = "api_port"
     API_URL = "api_url"
+    APP_URL = "app_url"
 
 
 class DevelopmentConfig(Config):
@@ -20,8 +21,13 @@ class DevelopmentConfig(Config):
 
     @property
     def API_URL(self):
-        """Returns the application port."""
+        """Returns the api url."""
         return DevelopmentConfig._read_secret(Config.API_URL)
+
+    @property
+    def APP_URL(self):
+        """Returns the application url."""
+        return DevelopmentConfig._read_secret(Config.APP_URL)
 
     @staticmethod
     def _read_secret(secret_name, default=None):
@@ -39,8 +45,13 @@ class ProductionConfig(Config):
 
     @property
     def API_URL(self):
-        """Returns the application port."""
+        """Returns the api url."""
         return ProductionConfig._read_secret(Config.API_URL)
+
+    @property
+    def APP_URL(self):
+        """Returns the application url."""
+        return ProductionConfig._read_secret(Config.APP_URL)
 
     @staticmethod
     def _read_secret(secret_name, default=None):

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -51,5 +51,6 @@ def get_config():
     """Returns the appropriate configuration class based on the environment."""
     env = os.getenv("ENV", "development").lower()
     if env == "production":
-        return ProductionConfig()
+        # return ProductionConfig()
+        return DevelopmentConfig()
     return DevelopmentConfig()

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -56,6 +56,7 @@ async def process_youtube_url(data: YouTubePitchShiftRequest):
         ydl_opts = {
             "outtmpl": output_file,
             "format": "best",
+            "geo_bypass": True,
         }
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -12,7 +12,7 @@ from app.api.model import (
     YouTubePitchShiftResponse,
     YouTubeURL,
 )
-from server.app.config import get_config
+from app.config import get_config
 import yt_dlp
 import logging
 from moviepy import VideoFileClip, AudioFileClip

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -5,18 +5,31 @@ from urllib import response
 from pydantic import ValidationError
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 from app.api.utils import get_title_from_url, iterfile, pitch_shift
 from app.api.model import (
     YouTubePitchShiftRequest,
     YouTubePitchShiftResponse,
     YouTubeURL,
 )
+from server.app.config import get_config
 import yt_dlp
 import logging
 from moviepy import VideoFileClip, AudioFileClip
 from pathlib import Path
 
 app = FastAPI()
+
+origins: list[str] = [get_config().API_URL]
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.post("/process", response_model=YouTubePitchShiftResponse)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 app = FastAPI()
 
-origins: list[str] = [get_config().API_URL]
+origins: list[str] = [get_config().APP_URL]
 
 
 app.add_middleware(

--- a/server/gunicorn.config.py
+++ b/server/gunicorn.config.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 from app.config import get_config
 
-bind = f"0.0.0.0:{get_config().APP_PORT}"
+bind = f"0.0.0.0:{get_config().API_PORT}"
 
 workers = multiprocessing.cpu_count()
 


### PR DESCRIPTION
The main issue with the previous pipeline is that it requires me to maintain an entire infrastructure like a vps which I am not willing to do so I am intentionally downgrading it from requiring docker swarm to just docker. The ONLY reason I decided to use docker swarm was using docker secrets which in hindsight is not needed for this application as of now.
